### PR TITLE
Fix extra_data not saving updated values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Fixed `SQLAlchemyUserMixin.extra_data` not saving updated values (Issue #2)
+
 ## [1.0.1](https://github.com/python-social-auth/social-storage-sqlalchemy/releases/tag/1.0.1) - 2017-01-29
 
 ### Changed

--- a/social_sqlalchemy/storage.py
+++ b/social_sqlalchemy/storage.py
@@ -12,6 +12,7 @@ from sqlalchemy import Column, Integer, String
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.types import PickleType, Text
 from sqlalchemy.schema import UniqueConstraint
+from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.mutable import MutableDict
 
 from social_core.storage import UserMixin, AssociationMixin, NonceMixin, \
@@ -87,10 +88,13 @@ class SQLAlchemyUserMixin(SQLAlchemyMixin, UserMixin):
     __table_args__ = (UniqueConstraint('provider', 'uid'),)
     id = Column(Integer, primary_key=True)
     provider = Column(String(32))
-    extra_data = Column(MutableDict.as_mutable(JSONType))
     uid = None
     user_id = None
     user = None
+
+    @declared_attr
+    def extra_data(cls):
+        return Column(MutableDict.as_mutable(JSONType))
 
     @classmethod
     def changed(cls, user):


### PR DESCRIPTION
Fixes #2 by turning the `SQLAlchemyUserMixin.extra_data` column into a declared attribute, so that `MutableDict` can properly attach event listeners to `extra_data` properties of objects using this mixin.