### PR TITLE
Use encodebytes instead of encodestring

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'Intended Audience :: Developers',
         'Environment :: Web Environment',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3'
     ],
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3'
     ],
+    python_requires='>=3.6',
     zip_safe=False
 )

--- a/social_sqlalchemy/storage.py
+++ b/social_sqlalchemy/storage.py
@@ -215,7 +215,7 @@ class SQLAlchemyAssociationMixin(SQLAlchemyMixin, AssociationMixin):
         except IndexError:
             assoc = cls(server_url=server_url,
                         handle=association.handle)
-        assoc.secret = base64.encodestring(association.secret).decode()
+        assoc.secret = base64.encodebytes(association.secret).decode()
         assoc.issued = association.issued
         assoc.lifetime = association.lifetime
         assoc.assoc_type = association.assoc_type


### PR DESCRIPTION
`base64.encodestring` is deprecated from python 3.1 and is dropped entirely in python 3.9.
This commit will ensure compatibility with newer versions of python.